### PR TITLE
Removing typedoc from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_install:
 
 script:
   # Build the website
-  - cd website && yarn install && yarn run typedoc && yarn run build && cd -
+  # Typedoc is currently disabled, .md files are manually edited in docs/objects folder
+  # - cd website && yarn install && yarn run typedoc && yarn run build && cd -
+  - cd website && yarn install && yarn run build && cd -
 
   # Generate and test NPM bundle
   # TODO - add semantic release, as soon as the team is ready to release


### PR DESCRIPTION
Typedoc run deletes the docs/object folder, leading to a 404 on https://fo.finos.org/docs/objects/rfq